### PR TITLE
fix: repair installer syntax & point Makefile to cmd/ai-chat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,10 +67,12 @@ readme: install-hugo
 
 docs-all: docs readme
 
-
+clean:
+	rm -f bin/ai-chat-linux-amd64
 
 build:
-	go build -o bin/ai-chat-linux-amd64 .
+	GOOS=linux GOARCH=amd64 \
+	go build -o bin/ai-chat-linux-amd64 ./cmd/ai-chat
 
 man:
 	cobra-cli man --dir docs/man

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,22 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 echo "== ai-chat-cli installer =="
 
 require() { command -v "$1" >/dev/null 2>&1 || { echo "Error: $1 not found" >&2; exit 1; }; }
@@ -30,15 +14,6 @@ fi
 
 if ! command -v docker >/dev/null 2>&1; then
     echo "Warning: docker not installed; some features may be disabled" >&2
-
-fi
-
-OPENAI_API_KEY=${OPENAI_API_KEY:-}
-if [ -z "$OPENAI_API_KEY" ]; then
-    read -rp "Enter OPENAI_API_KEY: " OPENAI_API_KEY
-fi
-
-
 fi
 
 OPENAI_API_KEY=${OPENAI_API_KEY:-}
@@ -57,71 +32,6 @@ if [ -x "$bin" ]; then
     sudo cp "$bin" /usr/local/bin/
   fi
 fi
-
-
-fi
-
-OPENAI_API_KEY=${OPENAI_API_KEY:-}
-if [ -z "$OPENAI_API_KEY" ]; then
-    read -rp "Enter OPENAI_API_KEY: " OPENAI_API_KEY
-fi
-[ -z "$OPENAI_API_KEY" ] && { echo "API key required" >&2; exit 1; }
-
-echo "-- building ai-chat..."
-go install ./cmd/ai-chat
-bin="$(go env GOPATH)/bin/ai-chat"
-if [ -x "$bin" ]; then
-  if [ -w /usr/local/bin ]; then
-    cp "$bin" /usr/local/bin/
-  else
-    sudo cp "$bin" /usr/local/bin/
-  fi
-fi
-
-
-fi
-
-OPENAI_API_KEY=${OPENAI_API_KEY:-}
-if [ -z "$OPENAI_API_KEY" ]; then
-    read -rp "Enter OPENAI_API_KEY: " OPENAI_API_KEY
-fi
-
-fi
-
-OPENAI_API_KEY=${OPENAI_API_KEY:-}
-if [ -z "$OPENAI_API_KEY" ]; then
-    read -rp "Enter OPENAI_API_KEY: " OPENAI_API_KEY
-fi
-
-
-[ -z "$OPENAI_API_KEY" ] && { echo "API key required" >&2; exit 1; }
-
-echo "-- building ai-chat..."
-go install ./cmd/ai-chat
-
-
-
-
-
-
-bin="$(go env GOPATH)/bin/ai-chat"
-if [ -x "$bin" ]; then
-  if [ -w /usr/local/bin ]; then
-    cp "$bin" /usr/local/bin/
-  else
-    sudo cp "$bin" /usr/local/bin/
-  fi
-fi
-
-
-
-
-
-
-
-
-
-
 
 config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/ai-chat"
 config_file="$config_dir/ai-chat.yaml"
@@ -140,36 +50,4 @@ if command -v pre-commit >/dev/null 2>&1; then
     esac
 fi
 
-
 echo "Done. Try running: ai-chat \"Hello\""
-
-echo "Done. Try: ai-chat \"Hello\""
-
-require(){ command -v "$1" >/dev/null 2>&1 || { echo "$1 required"; exit 1; }; }
-require go
-require docker
-require git
-
-go version | grep -q "go1.24" || { echo "Go 1.24.x required"; exit 1; }
-
-read -rp "OPENAI_API_KEY: " OPENAI_API_KEY
-[ -z "$OPENAI_API_KEY" ] && { echo "key required"; exit 1; }
-
-make deps && make build
-
-go install ./cmd/ai-chat
-
-if command -v pre-commit >/dev/null 2>&1; then
-    read -rp "Install git hooks? [y/N]: " ans
-    case "$ans" in
-        y|Y) pre-commit install;;
-    esac
-fi
-
-echo "Installation complete"
-
-
-
-
-
-

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
-# Wrapper script to run the interactive installer
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-exec "$SCRIPT_DIR/scripts/install.sh" "$@"
+set -euo pipefail
+# Wrapper script to run the interactive installer regardless of cwd
+SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${SCRIPT_DIR}/scripts/install.sh" "$@"


### PR DESCRIPTION
## Summary
- fix mismatched `fi` in installer script and streamline logic
- ensure `setup.sh` resolves installer path correctly
- add `clean` target and build cli from `cmd/ai-chat`

## Testing
- `OPENAI_API_KEY=dummy bash setup.sh`
- `make clean build`
- `make test` *(fails: invalid model)*
- `make security` *(fails: gosec not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847a5a59e6c8326866c36c7d30b3876