### PR TITLE
Fix config CLI and package release

### DIFF
--- a/.github/workflows/ci-final.yml
+++ b/.github/workflows/ci-final.yml
@@ -148,3 +148,8 @@ jobs:
         with:
           version: v2.10.2
           args: release --clean          # builds tar.gz, .deb, .rpm
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*

--- a/Makefile
+++ b/Makefile
@@ -97,9 +97,15 @@ prompt:
 
 snapshot:
 	@command -v goreleaser >/dev/null || (\
-		curl -sSL https://github.com/goreleaser/goreleaser/releases/download/v2.9.0/goreleaser_Linux_x86_64.tar.gz \
-		| tar -xz goreleaser && sudo mv goreleaser /usr/local/bin/)
+	curl -sSL https://github.com/goreleaser/goreleaser/releases/download/v2.9.0/goreleaser_Linux_x86_64.tar.gz \
+	| tar -xz goreleaser && sudo mv goreleaser /usr/local/bin/)
 	goreleaser release --snapshot --clean --skip=publish --skip=docker --skip=sign
+	
+package:
+	@command -v goreleaser >/dev/null || (\
+	curl -sSL https://github.com/goreleaser/goreleaser/releases/download/v2.9.0/goreleaser_Linux_x86_64.tar.gz \
+	| tar -xz goreleaser && sudo mv goreleaser /usr/local/bin/)
+	goreleaser release --snapshot --clean
 
 release:
 	       @command -v goreleaser >/dev/null || (\

--- a/cmd/ai-chat-cli/main.go
+++ b/cmd/ai-chat-cli/main.go
@@ -13,23 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package main
 
-import (
-	"os"
-	"path/filepath"
-	"testing"
-)
+import "github.com/jalsarraf0/ai-chat-cli/cmd"
 
-// TestDefaultPathTemp ensures fallback to temp when APPDATA and HOME are empty.
-func TestDefaultPathTemp(t *testing.T) {
-	Reset()
-	t.Setenv("XDG_CONFIG_HOME", "")
-	t.Setenv("APPDATA", "")
-	t.Setenv("HOME", "")
-	p := defaultPath()
-       want := filepath.Join(os.TempDir(), "ai-chat-cli", "config.yaml")
-	if p != want {
-		t.Fatalf("want %s got %s", want, p)
-	}
+func main() {
+	cmd.Execute()
 }

--- a/cmd/ai-chat-cli/main_test.go
+++ b/cmd/ai-chat-cli/main_test.go
@@ -13,23 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package main
 
-import (
-	"os"
-	"path/filepath"
-	"testing"
-)
+import "testing"
 
-// TestDefaultPathTemp ensures fallback to temp when APPDATA and HOME are empty.
-func TestDefaultPathTemp(t *testing.T) {
-	Reset()
-	t.Setenv("XDG_CONFIG_HOME", "")
-	t.Setenv("APPDATA", "")
-	t.Setenv("HOME", "")
-	p := defaultPath()
-       want := filepath.Join(os.TempDir(), "ai-chat-cli", "config.yaml")
-	if p != want {
-		t.Fatalf("want %s got %s", want, p)
-	}
+func TestMainFunc(t *testing.T) {
+	t.Setenv("AICHAT_OPENAI_API_KEY", "k")
+	main()
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/jalsarraf0/ai-chat-cli/internal/shell"
 	"github.com/jalsarraf0/ai-chat-cli/pkg/chat"
@@ -52,6 +53,10 @@ func newRootCmd() *cobra.Command {
 		Args:  cobra.ArbitraryArgs,
 		RunE:  askRunE(llmClient),
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			if strings.HasPrefix(cmd.CommandPath(), cmd.Root().Name()+" config") {
+				config.SkipValidation(true)
+				defer config.SkipValidation(false)
+			}
 			if err := config.Load(cfgFile); err != nil {
 				return err
 			}

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -9,11 +9,11 @@ before:
 
 # ─── Builds ──────────────────────────────────────────────────────────
 builds:
-  - id: linux_amd64
-    main: ./cmd/ai-chat
-    goos:  [linux]
+  - id: default
+    main: ./cmd/ai-chat-cli
+    goos: [linux]
     goarch: [amd64]
-    env:   [CGO_ENABLED=0]
+    env: [CGO_ENABLED=0]
     ldflags: >-
       -s -w
       -X main.version={{ .Version }}
@@ -23,9 +23,9 @@ builds:
 # ─── Archives ────────────────────────────────────────────────────────
 archives:
   - id: default
-    ids:     [linux_amd64]
+    ids:     [default]
     formats: [tar.gz]
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "ai-chat-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     files:
       - LICENSE*
       - README.md
@@ -34,8 +34,9 @@ archives:
 nfpms:
   # Debian package
   - id: deb
-    builds:   [linux_amd64]
+    builds:   [default]
     formats:  [deb]
+    package_name: ai-chat-cli
     section:  utils
     maintainer: Jamal Al-Sarraf <you@example.com>
     vendor:      AI-Chat-CLI
@@ -47,8 +48,9 @@ nfpms:
 
   # RPM package
   - id: rpm
-    builds:   [linux_amd64]
+    builds:   [default]
     formats:  [rpm]
+    package_name: ai-chat-cli
     maintainer: Jamal Al-Sarraf <you@example.com>
     vendor:      AI-Chat-CLI
     homepage:    https://github.com/jalsarraf0/ai-chat-cli
@@ -61,6 +63,10 @@ nfpms:
 checksum:
   name_template: checksums.txt
   algorithm: sha256
+
+sboms:
+  - id: default
+    artifacts: archive
 
 # ─── GitHub Release ─────────────────────────────────────────────────
 release:

--- a/internal/cli/test/config_integration_test.go
+++ b/internal/cli/test/config_integration_test.go
@@ -1,0 +1,56 @@
+package cli_test
+
+import (
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func buildBinary(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	exe := filepath.Join(tmp, "ai-chat")
+	if runtime.GOOS == "windows" {
+		exe += ".exe"
+	}
+	out, err := exec.Command("go", "build", "-o", exe, filepath.Join("..", "..", "..", "cmd", "ai-chat-cli")).CombinedOutput()
+	if err != nil {
+		t.Fatalf("build: %v\n%s", err, out)
+	}
+	return exe
+}
+
+func TestConfigCommandsIntegration(t *testing.T) {
+	exe := buildBinary(t)
+	cfg := filepath.Join(t.TempDir(), "c.yaml")
+
+	cmd := exec.Command(exe, "--config", cfg, "config", "set", "openai_api_key", "abc")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("set: %v\n%s", err, out)
+	}
+
+	out, err := exec.Command(exe, "--config", cfg, "config", "get", "openai_api_key").Output()
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if string(out) == "" || string(out)[:3] != "abc" {
+		t.Fatalf("unexpected get output: %s", out)
+	}
+
+	out, err = exec.Command(exe, "--config", cfg, "config", "list").Output()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatalf("list empty")
+	}
+
+	out, err = exec.Command(exe, "--config", cfg, "config", "show").Output()
+	if err != nil {
+		t.Fatalf("show: %v", err)
+	}
+	if len(out) == 0 || !filepath.IsAbs(cfg) {
+		t.Fatalf("show output bad: %s", out)
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,15 +25,20 @@ import (
 )
 
 var (
-	v    = viper.New()
-	path string
+	v            = viper.New()
+	path         string
+	skipValidate bool
 )
 
 // Reset is intended for tests to reinitialize the package state.
 func Reset() {
 	v = viper.New()
 	path = ""
+	skipValidate = false
 }
+
+// SkipValidation controls whether Load skips validation. Intended for CLI config commands.
+func SkipValidation(enable bool) { skipValidate = enable }
 
 // Load reads configuration from file, env and flags.
 func Load(p string) error {
@@ -53,6 +58,9 @@ func Load(p string) error {
 		if !errors.As(err, &e) && !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
+	}
+	if skipValidate {
+		return nil
 	}
 	return validate()
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -79,8 +79,8 @@ func TestDefaultPathXDG(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("AICHAT_OPENAI_API_KEY", "k")
 	t.Setenv("XDG_CONFIG_HOME", dir)
-	p := defaultPath()
-	want := filepath.Join(dir, "ai-chat", "ai-chat.yaml")
+       p := defaultPath()
+       want := filepath.Join(dir, "ai-chat-cli", "config.yaml")
 	if p != want {
 		t.Fatalf("want %s got %s", want, p)
 	}
@@ -90,7 +90,7 @@ func TestDefaultPathHome(t *testing.T) {
 	Reset()
 	t.Setenv("XDG_CONFIG_HOME", "")
 	p := defaultPath()
-	if !strings.Contains(p, ".config/ai-chat/ai-chat.yaml") {
+       if !strings.Contains(p, ".config/ai-chat-cli/config.yaml") {
 		t.Fatalf("unexpected %s", p)
 	}
 }
@@ -101,7 +101,7 @@ func TestDefaultPathFallback(t *testing.T) {
 	oldHome := os.Getenv("HOME")
 	t.Setenv("HOME", "")
 	p := defaultPath()
-	if !strings.Contains(p, "ai-chat/ai-chat.yaml") {
+       if !strings.Contains(p, "ai-chat-cli/config.yaml") {
 		t.Fatalf("unexpected %s", p)
 	}
 	if oldHome != "" {

--- a/pkg/config/defaultpath.go
+++ b/pkg/config/defaultpath.go
@@ -32,5 +32,5 @@ func defaultPathImpl() string {
 			base = os.TempDir()
 		}
 	}
-	return filepath.Join(base, "ai-chat", "ai-chat.yaml")
+	return filepath.Join(base, "ai-chat-cli", "config.yaml")
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,53 +1,57 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 echo "== ai-chat-cli installer =="
 
-require() { command -v "$1" >/dev/null 2>&1 || { echo "Error: $1 not found" >&2; exit 1; }; }
-require go
-require git
+pkg_install() {
+    if command -v apt-get >/dev/null 2>&1; then
+        sudo apt-get update -y && sudo apt-get install -y "$@"
+    elif command -v dnf >/dev/null 2>&1; then
+        sudo dnf install -y "$@"
+    else
+        echo "Unsupported OS" >&2
+        exit 1
+    fi
+}
+
+ensure() { command -v "$1" >/dev/null 2>&1 || pkg_install "$1"; }
+
+ensure git
+ensure curl
+ensure go
 
 if ! go version | grep -q "go1.24"; then
     echo "Go 1.24.x required" >&2
     exit 1
 fi
 
-if ! command -v docker >/dev/null 2>&1; then
-    echo "Warning: docker not installed; some features may be disabled" >&2
-fi
-
 OPENAI_API_KEY=${OPENAI_API_KEY:-}
 if [ -z "$OPENAI_API_KEY" ]; then
-    read -rp "Enter OPENAI_API_KEY: " OPENAI_API_KEY
+    read -rp "Enter OPENAI_API_KEY (leave blank to edit later): " OPENAI_API_KEY || true
 fi
-[ -z "$OPENAI_API_KEY" ] && { echo "API key required" >&2; exit 1; }
 
-echo "-- building ai-chat..."
-go install ./cmd/ai-chat
-bin="$(go env GOPATH)/bin/ai-chat"
+echo "-- building ai-chat-cli..."
+go install ./cmd/ai-chat-cli
+bin="$(go env GOPATH)/bin/ai-chat-cli"
 if [ -x "$bin" ]; then
+  target=/usr/local/bin/ai-chat-cli
   if [ -w /usr/local/bin ]; then
-    cp "$bin" /usr/local/bin/
+    cp "$bin" "$target"
   else
-    sudo cp "$bin" /usr/local/bin/
+    sudo cp "$bin" "$target"
   fi
 fi
 
-config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/ai-chat"
-config_file="$config_dir/ai-chat.yaml"
+config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/ai-chat-cli"
+config_file="$config_dir/config.yaml"
 mkdir -p "$config_dir"
 if [ ! -f "$config_file" ]; then
-cat >"$config_file" <<EOF
+    cat >"$config_file" <<EOF
 openai_api_key: $OPENAI_API_KEY
 model: gpt-4o
 EOF
+    echo "Created $config_file. Add your API key if empty." >&2
 fi
 
-if command -v pre-commit >/dev/null 2>&1; then
-    read -rp "Install git hooks? [y/N]: " ans
-    case "$ans" in
-        y|Y) pre-commit install;;
-    esac
-fi
-
-echo "Done. Try running: ai-chat \"Hello\""
+echo '✅ Installed!  Try:  ai-chat "Hello"'


### PR DESCRIPTION
## Summary
- wire up `ai-chat config` commands with proper validation skipping
- add integration tests for config CLI via exec
- default config path uses `~/.config/ai-chat-cli/config.yaml`
- hardened shell installer with prerequisite checks and nicer UX
- package via goreleaser with archives and nfpm packages; upload artifacts in CI

## Testing
- `make test`
- `make package`
- `goreleaser release --snapshot --clean`


------
https://chatgpt.com/codex/tasks/task_e_6847ae7fd19c83268ccd8e0fb836b4f3