### PR TITLE
fix(cli): refine config validation check

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,6 +45,24 @@ var (
 	profile       string
 )
 
+func shouldSkipCfgValidation(cmd *cobra.Command) bool {
+	root := cmd.Root().Name()
+	allowed := map[string]struct{}{
+		root + " config":      {},
+		root + " version":     {},
+		root + " ping":        {},
+		root + " assets":      {},
+		root + " completion":  {},
+		root + " healthcheck": {},
+	}
+	for a := range allowed {
+		if strings.HasPrefix(cmd.CommandPath(), a) {
+			return true
+		}
+	}
+	return false
+}
+
 func newRootCmd() *cobra.Command {
 	detectedShell = shell.Detect()
 	cmd := &cobra.Command{
@@ -53,7 +71,7 @@ func newRootCmd() *cobra.Command {
 		Args:  cobra.ArbitraryArgs,
 		RunE:  askRunE(llmClient),
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-			if strings.HasPrefix(cmd.CommandPath(), cmd.Root().Name()+" config") {
+			if shouldSkipCfgValidation(cmd) {
 				config.SkipValidation(true)
 				defer config.SkipValidation(false)
 			}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -42,7 +42,11 @@ func TestRootExecute(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("SHELL", "/bin/bash")
-			t.Setenv("AICHAT_OPENAI_API_KEY", "key")
+			if tt.name == "ping" || tt.name == "ping-verbose" || tt.name == "version" {
+				t.Setenv("AICHAT_OPENAI_API_KEY", "")
+			} else {
+				t.Setenv("AICHAT_OPENAI_API_KEY", "key")
+			}
 			config.Reset()
 			cfg := filepath.Join(t.TempDir(), "c.yaml")
 			cmd := newRootCmd()
@@ -66,7 +70,7 @@ func TestRootExecute(t *testing.T) {
 
 func TestExecuteFailure(t *testing.T) {
 	if os.Getenv("GO_WANT_HELPER_PROCESS") == "1" {
-		os.Args = []string{"ai-chat", "ping"}
+		os.Args = []string{"ai-chat", "hello"}
 		Execute()
 		return
 	}


### PR DESCRIPTION
## Summary
- allow root commands like `version` or `ping` to bypass config validation
- update skip logic with map-based lookup

## Testing
- `make test`
- `gosec ./...`
- `govulncheck ./...`
- `goreleaser release --snapshot --clean --skip=publish --skip=docker --skip=sign`


------
https://chatgpt.com/codex/tasks/task_e_68483ac0d8b88326b93273f806113eaa