### PR TITLE
Add login command and API key check

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,13 @@ ai-chat "Hello"
 ```
 
 The installer checks prerequisites, compiles the binary and copies it to `/usr/local/bin`.
-It stores your API key in `$XDG_CONFIG_HOME/ai-chat/ai-chat.yaml` so you only enter it once.
+Set your OpenAI API key first with `export OPENAI_API_KEY=<key>` or run:
+
+```bash
+ai-chat login <key>
+```
+
+Your key is stored in `$XDG_CONFIG_HOME/ai-chat/ai-chat.yaml` so you only enter it once.
 
 ---
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"github.com/jalsarraf0/ai-chat-cli/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+func newLoginCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "login <openai_api_key>",
+		Short: "Set OpenAI API key",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return config.Set("openai_api_key", args[0])
+		},
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,6 +28,8 @@ var (
 	v            = viper.New()
 	path         string
 	skipValidate bool
+	// ErrAPIKeyMissing indicates the OpenAI key was not provided.
+	ErrAPIKeyMissing = errors.New("openai_api_key required")
 )
 
 // Reset is intended for tests to reinitialize the package state.
@@ -110,7 +112,7 @@ var allowedModels = map[string]struct{}{
 
 func validate() error {
 	if k := v.GetString("openai_api_key"); k == "" {
-		return errors.New("openai_api_key required")
+		return ErrAPIKeyMissing
 	}
 	if m := v.GetString("model"); m != "" {
 		if _, ok := allowedModels[m]; !ok {


### PR DESCRIPTION
## Summary
- allow skipping config validation for `login` command
- add new `login` command to set API key
- show helpful error when API key missing
- document login usage in README

## Testing
- `npm install`
- `npm audit`
- `make docs`
- `make test`
- `./run_ci_local.sh` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_684847dc96a48326bc8e95112beb6d33