### PR TITLE
Fix uninstall script path

### DIFF
--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -2,7 +2,11 @@
 set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-BIN="$(go env GOBIN 2>/dev/null || echo "$HOME/go/bin")/ai-chat"
+BIN=$(go env GOBIN 2>/dev/null)
+if [ -z "$BIN" ]; then
+    BIN="$(go env GOPATH 2>/dev/null)/bin"
+fi
+BIN="$BIN/ai-chat"
 CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/ai-chat"
 
 if [ "$1" != "--yes" ]; then


### PR DESCRIPTION
## Summary
- fix default uninstall location when `GOBIN` is empty

## Testing
- `go run ./cmd/ai-chat --help | head -n 20`
- `go run ./cmd/ai-chat tui --height 5 >/tmp/tui_output.txt && tail -n 20 /tmp/tui_output.txt`
- `go run ./cmd/ai-chat ping`
- `go run ./cmd/ai-chat healthcheck`
- `go run ./cmd/ai-chat version`
- `go run ./cmd/ai-chat "hello" | head -n 5`
- `go run ./cmd/ai-chat aiops --help`
- `bash scripts/install.sh --prefix /tmp/inst`
- `bash uninstall.sh --yes`
- `golangci-lint run ./...`
- `go test -race -covermode=atomic -coverprofile=coverage.out -tags unit ./...`
- `gosec ./...`
- `govulncheck ./...`
- `go build ./cmd/ai-chat`
- `addlicense -check $(git ls-files '*.go')`


------
https://chatgpt.com/codex/tasks/task_e_6848516a99c88326b31e4d23c485b590