### PR TITLE
use openai client by default

### DIFF
--- a/cmd/ai-chat-cli/main_test.go
+++ b/cmd/ai-chat-cli/main_test.go
@@ -18,6 +18,6 @@ package main
 import "testing"
 
 func TestMainFunc(t *testing.T) {
-	t.Setenv("AICHAT_OPENAI_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	main()
 }

--- a/cmd/ai-chat/main_test.go
+++ b/cmd/ai-chat/main_test.go
@@ -18,6 +18,6 @@ package main
 import "testing"
 
 func TestMainFunc(t *testing.T) {
-	t.Setenv("AICHAT_OPENAI_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	main()
 }

--- a/cmd/ask_roundtrip_test.go
+++ b/cmd/ask_roundtrip_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestAskCommand(t *testing.T) {
-	t.Setenv("AICHAT_OPENAI_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	out := new(bytes.Buffer)
 	llmClient = mock.New("ok")
 	root := newRootCmd()

--- a/cmd/ask_test.go
+++ b/cmd/ask_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestRootAsk(t *testing.T) {
-	t.Setenv("AICHAT_OPENAI_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	buf := new(bytes.Buffer)
 	llmClient = mock.New("h", "i")
 	cmd := newRootCmd()
@@ -41,7 +41,7 @@ func TestRootAsk(t *testing.T) {
 }
 
 func TestRootAskFlags(t *testing.T) {
-	t.Setenv("AICHAT_OPENAI_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	buf := new(bytes.Buffer)
 	llmClient = mock.New("z")
 	cmd := newRootCmd()
@@ -62,7 +62,7 @@ func (errorClient) Completion(_ context.Context, _ llm.Request) (llm.Stream, err
 }
 
 func TestRootAskError(t *testing.T) {
-	t.Setenv("AICHAT_OPENAI_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	llmClient = errorClient{}
 	cmd := newRootCmd()
 	cmd.SetArgs([]string{"oops"})

--- a/cmd/ask_write_error_test.go
+++ b/cmd/ask_write_error_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestAskCmdWriteError(t *testing.T) {
-	t.Setenv("AICHAT_OPENAI_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	llmClient = mock.New("x")
 	cmd := newRootCmd()
 	cmd.SetArgs([]string{"hi"})

--- a/cmd/assets_error_test.go
+++ b/cmd/assets_error_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestAssetsExportErrors(t *testing.T) {
-	t.Setenv("AICHAT_OPENAI_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	cfg := filepath.Join(t.TempDir(), "c.yaml")
 	dest := filepath.Join(t.TempDir(), "out.json")
 

--- a/cmd/assets_list_error_test.go
+++ b/cmd/assets_list_error_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestAssetsListWriteError(t *testing.T) {
-	t.Setenv("AICHAT_OPENAI_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	cfg := filepath.Join(t.TempDir(), "c.yaml")
 	root := newRootCmd()
 	root.SetArgs([]string{"--config", cfg, "assets", "list"})
@@ -33,7 +33,7 @@ func TestAssetsListWriteError(t *testing.T) {
 }
 
 func TestAssetsCatError(t *testing.T) {
-	t.Setenv("AICHAT_OPENAI_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	cfg := filepath.Join(t.TempDir(), "c.yaml")
 	root := newRootCmd()
 	root.SetArgs([]string{"--config", cfg, "assets", "cat", "missing.txt"})
@@ -43,7 +43,7 @@ func TestAssetsCatError(t *testing.T) {
 }
 
 func TestAssetsExportMkdirError(t *testing.T) {
-	t.Setenv("AICHAT_OPENAI_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	cfg := filepath.Join(t.TempDir(), "c.yaml")
 	base := filepath.Join(t.TempDir(), "dir")
 	if err := os.MkdirAll(base, 0o755); err != nil {

--- a/cmd/assets_roundtrip_test.go
+++ b/cmd/assets_roundtrip_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestAssetsRoundTrip(t *testing.T) {
-	t.Setenv("AICHAT_OPENAI_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	cfg := filepath.Join(t.TempDir(), "c.yaml")
 	dest := filepath.Join(t.TempDir(), "out.json")
 	root := newRootCmd()

--- a/cmd/assets_test.go
+++ b/cmd/assets_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestAssetsCommands(t *testing.T) {
-	t.Setenv("AICHAT_OPENAI_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	config.Reset()
 	cfg := filepath.Join(t.TempDir(), "c.yaml")
 	root := newRootCmd()
@@ -78,7 +78,7 @@ func TestAssetsCommands(t *testing.T) {
 }
 
 func TestAssetsExportError(t *testing.T) {
-	t.Setenv("AICHAT_OPENAI_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	config.Reset()
 	cfg := filepath.Join(t.TempDir(), "c.yaml")
 	dest := filepath.Join(t.TempDir(), "dup.json")

--- a/cmd/config_edit_windows_test.go
+++ b/cmd/config_edit_windows_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestConfigEditRunWindows(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("AICHAT_OPENAI_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	config.Reset()
 	editor := filepath.Join(dir, "ed.bat")
 	// simple batch file that exits successfully

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestConfigCommands(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("AICHAT_OPENAI_API_KEY", "key")
+	t.Setenv("OPENAI_API_KEY", "key")
 	config.Reset()
 	cfg := newRootCmd()
 	cfg.SetArgs([]string{"--config", dir + "/c.yaml", "config", "set", "openai_api_key", "abc"})
@@ -79,7 +79,7 @@ func TestConfigCommands(t *testing.T) {
 
 func TestConfigShowMissing(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("AICHAT_OPENAI_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	config.Reset()
 	c := newRootCmd()
 	c.SetArgs([]string{"--config", filepath.Join(dir, "c.yaml"), "config", "show"})
@@ -90,7 +90,7 @@ func TestConfigShowMissing(t *testing.T) {
 
 func TestConfigSetInvalid(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("AICHAT_OPENAI_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	config.Reset()
 	c := newRootCmd()
 	c.SetArgs([]string{"--config", filepath.Join(dir, "c.yaml"), "config", "set", "model", "bad"})
@@ -101,7 +101,7 @@ func TestConfigSetInvalid(t *testing.T) {
 
 func TestConfigGetMissingKey(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("AICHAT_OPENAI_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	config.Reset()
 	c := newRootCmd()
 	c.SetArgs([]string{"--config", filepath.Join(dir, "c.yaml"), "config", "get", "missing"})
@@ -116,7 +116,7 @@ func TestConfigCorruptFile(t *testing.T) {
 	if err := os.WriteFile(cfgFile, []byte(":bad"), 0o600); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	t.Setenv("AICHAT_OPENAI_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	config.Reset()
 	c := newRootCmd()
 	c.SetArgs([]string{"--config", cfgFile, "config", "list"})
@@ -130,7 +130,7 @@ func TestConfigEditRun(t *testing.T) {
 		t.Skip("skip on windows")
 	}
 	dir := t.TempDir()
-	t.Setenv("AICHAT_OPENAI_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	config.Reset()
 	editor := filepath.Join(dir, "ed.sh")
 	if err := os.WriteFile(editor, []byte("#!/bin/sh\n"), 0o755); err != nil {
@@ -149,7 +149,7 @@ func TestConfigEditDefaultEditor(t *testing.T) {
 		t.Skip("skip on windows")
 	}
 	dir := t.TempDir()
-	t.Setenv("AICHAT_OPENAI_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	config.Reset()
 	vi := filepath.Join(dir, "vi")
 	if err := os.WriteFile(vi, []byte("#!/bin/sh\n"), 0o755); err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"reflect"
 	"strings"
 
 	"github.com/jalsarraf0/ai-chat-cli/internal/shell"
@@ -29,13 +30,15 @@ import (
 	"github.com/jalsarraf0/ai-chat-cli/pkg/config"
 	"github.com/jalsarraf0/ai-chat-cli/pkg/llm"
 	"github.com/jalsarraf0/ai-chat-cli/pkg/llm/mock"
+	"github.com/jalsarraf0/ai-chat-cli/pkg/llm/openai"
 	"github.com/spf13/cobra"
 )
 
 // rootCmd represents the base command when called without any subcommands
 var (
 	chatClient    chat.Client = chat.NewMockClient()
-	llmClient     llm.Client  = mock.New("hello")
+	defaultLLM    llm.Client  = mock.New("hello")
+	llmClient     llm.Client  = defaultLLM
 	verbose       bool
 	detectedShell shell.Kind
 	cfgFile       string
@@ -79,11 +82,14 @@ func newRootCmd() *cobra.Command {
 			}
 			if err := config.Load(cfgFile); err != nil {
 				if errors.Is(err, config.ErrAPIKeyMissing) {
-					return fmt.Errorf("%w\nset with 'ai-chat login <key>' or env AI_CHAT_API_KEY", err)
+					return fmt.Errorf("%w\nset with 'ai-chat login <key>' or env OPENAI_API_KEY", err)
 				}
 				return err
 			}
 			log.Printf("INFO: config %s", config.Path())
+			if reflect.DeepEqual(llmClient, defaultLLM) {
+				llmClient = openai.New()
+			}
 			if verbose {
 				if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "shell=%s\n", detectedShell); err != nil {
 					cmd.Println("Error:", err)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -43,9 +43,9 @@ func TestRootExecute(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("SHELL", "/bin/bash")
 			if tt.name == "ping" || tt.name == "ping-verbose" || tt.name == "version" {
-				t.Setenv("AICHAT_OPENAI_API_KEY", "")
+				t.Setenv("OPENAI_API_KEY", "")
 			} else {
-				t.Setenv("AICHAT_OPENAI_API_KEY", "key")
+				t.Setenv("OPENAI_API_KEY", "key")
 			}
 			config.Reset()
 			cfg := filepath.Join(t.TempDir(), "c.yaml")
@@ -77,12 +77,12 @@ func TestExecuteFailure(t *testing.T) {
 	cmd := exec.Command(os.Args[0], "-test.run=TestExecuteFailure")
 	env := []string{"GO_WANT_HELPER_PROCESS=1"}
 	for _, e := range os.Environ() {
-		if !strings.HasPrefix(e, "AICHAT_OPENAI_API_KEY=") {
+		if !strings.HasPrefix(e, "OPENAI_API_KEY=") {
 			env = append(env, e)
 		}
 	}
 	cmd.Env = env
-	// Ensure config.Load fails by not setting AICHAT_OPENAI_API_KEY
+	// Ensure config.Load fails by not setting OPENAI_API_KEY
 	err := cmd.Run()
 	if err == nil {
 		t.Fatalf("expected exit")

--- a/cmd/tui_cmd_test.go
+++ b/cmd/tui_cmd_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestTuiCmd(t *testing.T) {
-	t.Setenv("AICHAT_OPENAI_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	ran := false
 	teaRun = func(_ *tea.Program) (tea.Model, error) { ran = true; return nil, nil }
 	defer func() { teaRun = func(p *tea.Program) (tea.Model, error) { return p.Run() } }()

--- a/cmd/tui_custom_test.go
+++ b/cmd/tui_custom_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestTuiCmdCustomTheme(t *testing.T) {
-	t.Setenv("AICHAT_OPENAI_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	ran := false
 	teaRun = func(_ *tea.Program) (tea.Model, error) { ran = true; return nil, nil }
 	defer func() { teaRun = func(p *tea.Program) (tea.Model, error) { return p.Run() } }()

--- a/docs/codex/phase-4-config.md
+++ b/docs/codex/phase-4-config.md
@@ -16,7 +16,7 @@ Author: Jamal Al‑Sarraf <jalsarraf0@gmail.com>
 |---|-------------|---------|
 | 1 | **Config package (`pkg/config`)** | Wrap **spf13/viper** with helper functions:<br>`Load()`, `Save()`, `GetString(key)`, `Set(key,val)`. Default path `~/.config/ai-chat/config.yaml` on Unix & `%APPDATA%\ai-chat\config.yaml` on Windows. |
 | 2 | **CLI sub‑command `ai-chat config`** | Sub‑commands:<br>`show` (print current YAML), `set <key> <value>`, `edit` (opens `$EDITOR`, fallback to `vi`/`notepad`). |
-| 3 | **Environment & flag overrides** | • ENV prefix `AICHAT_` (e.g., `AICHAT_OPENAI_API_KEY`).<br>• Global `--config <file>` flag to override path. |
+| 3 | **Environment & flag overrides** | • ENV prefix `AICHAT_` (e.g., `OPENAI_API_KEY`).<br>• Global `--config <file>` flag to override path. |
 | 4 | **Validation hooks** | Custom validators (e.g., API key non-empty, model name allowed). Fail fast with helpful error. |
 | 5 | **Docs & examples** | Update README + add `docs/config.md` detailing keys. |
 

--- a/docs/codex/phase-7-llm.md
+++ b/docs/codex/phase-7-llm.md
@@ -24,7 +24,7 @@ go test -race -covermode=atomic -coverprofile=coverage.out -tags unit ./...
    ```
 6. **macOS cache fix**: pre‑clean `${{ env.CACHE_DIR }}` before `actions/cache@v3` restore.
 7. **Docs**: update `docs/llm.md` with “Unit vs Live” test section.
-8. **Gate**: total coverage ≥ 90 % on all OSes; live tests remain opt‑in (`AI_CHAT_API_KEY`).
+8. **Gate**: total coverage ≥ 90 % on all OSes; live tests remain opt‑in (`OPENAI_API_KEY`).
 
 ---
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -8,7 +8,7 @@ The CLI stores settings in a YAML file located at:
 
 Environment variables with prefix `AICHAT_` override file values. Keys include:
 
-- `openai_api_key` – API token (required)
+- `openai_api_key` – API token (required, env var `OPENAI_API_KEY`)
 - `model` – allowed values `gpt-4`, `gpt-3.5-turbo`
 
 Use `ai-chat config show` to print the config file path and contents, `ai-chat config set <key> <value>` to change a value, or `ai-chat config edit` to open the file in your editor.

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -1,6 +1,6 @@
 # LLM Usage
 
-`ai-chat` streams chat completions to stdout. Set your OpenAI key in `ai-chat.yaml` (`openai_api_key`) or `AI_CHAT_API_KEY`.
+`ai-chat` streams chat completions to stdout. Set your OpenAI key in `ai-chat.yaml` (`openai_api_key`) or `OPENAI_API_KEY`.
 
 | Flag | Config key | Purpose |
 |------|------------|---------|
@@ -18,4 +18,4 @@ Run offline tests with:
 go test -tags unit ./...
 ```
 
-Live tests hit the real API only when `AI_CHAT_API_KEY` is set. Use `make live-openai-test` to run them.
+Live tests hit the real API only when `OPENAI_API_KEY` is set. Use `make live-openai-test` to run them.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -52,6 +52,7 @@ func Load(p string) error {
 	v.SetConfigType("yaml")
 	v.SetEnvPrefix("AICHAT")
 	v.AutomaticEnv()
+	_ = v.BindEnv("openai_api_key", "OPENAI_API_KEY")
 	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
 		return err
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -26,7 +26,7 @@ func TestLoadSetEnv(t *testing.T) {
 	Reset()
 	dir := t.TempDir()
 	file := filepath.Join(dir, "config.yaml")
-	t.Setenv("AICHAT_OPENAI_API_KEY", "envkey")
+	t.Setenv("OPENAI_API_KEY", "envkey")
 	if err := Load(file); err != nil {
 		t.Fatalf("load: %v", err)
 	}
@@ -49,7 +49,7 @@ func TestValidation(t *testing.T) {
 	Reset()
 	dir := t.TempDir()
 	file := filepath.Join(dir, "c.yaml")
-	t.Setenv("AICHAT_OPENAI_API_KEY", "key")
+	t.Setenv("OPENAI_API_KEY", "key")
 	if err := Load(file); err != nil {
 		t.Fatalf("load: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestPathAndSave(t *testing.T) {
 	Reset()
 	dir := t.TempDir()
 	file := filepath.Join(dir, "c.yaml")
-	t.Setenv("AICHAT_OPENAI_API_KEY", "key")
+	t.Setenv("OPENAI_API_KEY", "key")
 	if err := Load(file); err != nil {
 		t.Fatalf("load: %v", err)
 	}
@@ -77,10 +77,10 @@ func TestPathAndSave(t *testing.T) {
 func TestDefaultPathXDG(t *testing.T) {
 	Reset()
 	dir := t.TempDir()
-	t.Setenv("AICHAT_OPENAI_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	t.Setenv("XDG_CONFIG_HOME", dir)
-       p := defaultPath()
-       want := filepath.Join(dir, "ai-chat-cli", "config.yaml")
+	p := defaultPath()
+	want := filepath.Join(dir, "ai-chat-cli", "config.yaml")
 	if p != want {
 		t.Fatalf("want %s got %s", want, p)
 	}
@@ -90,7 +90,7 @@ func TestDefaultPathHome(t *testing.T) {
 	Reset()
 	t.Setenv("XDG_CONFIG_HOME", "")
 	p := defaultPath()
-       if !strings.Contains(p, ".config/ai-chat-cli/config.yaml") {
+	if !strings.Contains(p, ".config/ai-chat-cli/config.yaml") {
 		t.Fatalf("unexpected %s", p)
 	}
 }
@@ -101,7 +101,7 @@ func TestDefaultPathFallback(t *testing.T) {
 	oldHome := os.Getenv("HOME")
 	t.Setenv("HOME", "")
 	p := defaultPath()
-       if !strings.Contains(p, "ai-chat-cli/config.yaml") {
+	if !strings.Contains(p, "ai-chat-cli/config.yaml") {
 		t.Fatalf("unexpected %s", p)
 	}
 	if oldHome != "" {
@@ -113,7 +113,7 @@ func TestSetValidModel(t *testing.T) {
 	Reset()
 	dir := t.TempDir()
 	file := filepath.Join(dir, "c.yaml")
-	t.Setenv("AICHAT_OPENAI_API_KEY", "key")
+	t.Setenv("OPENAI_API_KEY", "key")
 	if err := Load(file); err != nil {
 		t.Fatalf("load: %v", err)
 	}
@@ -126,7 +126,7 @@ func TestLoadExistingFile(t *testing.T) {
 	Reset()
 	dir := t.TempDir()
 	file := filepath.Join(dir, "c.yaml")
-	t.Setenv("AICHAT_OPENAI_API_KEY", "key")
+	t.Setenv("OPENAI_API_KEY", "key")
 	if err := Load(file); err != nil {
 		t.Fatalf("load: %v", err)
 	}
@@ -134,7 +134,7 @@ func TestLoadExistingFile(t *testing.T) {
 		t.Fatalf("set: %v", err)
 	}
 	Reset()
-	t.Setenv("AICHAT_OPENAI_API_KEY", "key")
+	t.Setenv("OPENAI_API_KEY", "key")
 	if err := Load(file); err != nil {
 		t.Fatalf("reload: %v", err)
 	}
@@ -156,7 +156,7 @@ func TestSaveError(t *testing.T) {
 	Reset()
 	dir := t.TempDir()
 	file := filepath.Join(dir, "c.yaml")
-	t.Setenv("AICHAT_OPENAI_API_KEY", "key")
+	t.Setenv("OPENAI_API_KEY", "key")
 	if err := Load(file); err != nil {
 		t.Fatalf("load: %v", err)
 	}
@@ -170,7 +170,7 @@ func TestLoadInvalidYAML(t *testing.T) {
 	Reset()
 	dir := t.TempDir()
 	file := filepath.Join(dir, "c.yaml")
-	t.Setenv("AICHAT_OPENAI_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	if err := os.WriteFile(file, []byte(": bad"), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
@@ -186,7 +186,7 @@ func TestLoadDirError(t *testing.T) {
 	if err := os.Mkdir(path, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	t.Setenv("AICHAT_OPENAI_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	if err := Load(path); err == nil {
 		t.Fatalf("expected error")
 	}
@@ -196,7 +196,7 @@ func TestGetters(t *testing.T) {
 	Reset()
 	dir := t.TempDir()
 	file := filepath.Join(dir, "c.yaml")
-	t.Setenv("AICHAT_OPENAI_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	if err := Load(file); err != nil {
 		t.Fatalf("load: %v", err)
 	}
@@ -213,7 +213,7 @@ func TestAllAndIsSet(t *testing.T) {
 	Reset()
 	dir := t.TempDir()
 	file := filepath.Join(dir, "c.yaml")
-	t.Setenv("AICHAT_OPENAI_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	if err := Load(file); err != nil {
 		t.Fatalf("load: %v", err)
 	}
@@ -233,15 +233,15 @@ func TestAllAndIsSet(t *testing.T) {
 }
 
 func TestSkipValidation(t *testing.T) {
-    Reset()
-    dir := t.TempDir()
-    file := filepath.Join(dir, "c.yaml")
-    SkipValidation(true)
-    t.Cleanup(func() { SkipValidation(false) })
-    if err := Load(file); err != nil {
-        t.Fatalf("load skip: %v", err)
-    }
-    if Path() != file {
-        t.Fatalf("path %s", Path())
-    }
+	Reset()
+	dir := t.TempDir()
+	file := filepath.Join(dir, "c.yaml")
+	SkipValidation(true)
+	t.Cleanup(func() { SkipValidation(false) })
+	if err := Load(file); err != nil {
+		t.Fatalf("load skip: %v", err)
+	}
+	if Path() != file {
+		t.Fatalf("path %s", Path())
+	}
 }

--- a/pkg/llm/openai/openai.go
+++ b/pkg/llm/openai/openai.go
@@ -55,7 +55,7 @@ type Client struct {
 
 // New creates a Client reading credentials from env or config.
 func New(opts ...Option) Client {
-	key := os.Getenv("AI_CHAT_API_KEY")
+	key := os.Getenv("OPENAI_API_KEY")
 	if key == "" {
 		key = config.GetString("openai_api_key")
 	}

--- a/pkg/llm/openai/openai_test.go
+++ b/pkg/llm/openai/openai_test.go
@@ -25,8 +25,8 @@ import (
 )
 
 func TestLiveCompletion(t *testing.T) {
-	if os.Getenv("AI_CHAT_API_KEY") == "" {
-		t.Skip("AI_CHAT_API_KEY not set")
+	if os.Getenv("OPENAI_API_KEY") == "" {
+		t.Skip("OPENAI_API_KEY not set")
 	}
 	c := New()
 	s, err := c.Completion(context.Background(), llm.Request{

--- a/pkg/llm/openai/stream_test.go
+++ b/pkg/llm/openai/stream_test.go
@@ -40,7 +40,7 @@ func TestCompletionStream(t *testing.T) {
 		}
 	}))
 	defer srv.Close()
-	t.Setenv("AI_CHAT_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	t.Setenv("AICHAT_BASE_URL", srv.URL)
 	c := New()
 	s, err := c.Completion(context.Background(), llm.Request{Model: "m", Messages: []llm.Message{{Role: "user", Content: "q"}}})
@@ -65,7 +65,7 @@ func TestCompletionHTTPError(t *testing.T) {
 		}
 	}))
 	defer srv.Close()
-	t.Setenv("AI_CHAT_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	t.Setenv("AICHAT_BASE_URL", srv.URL)
 	c := New()
 	_, err := c.Completion(context.Background(), llm.Request{Model: "m"})

--- a/pkg/llm/openai/unit_test.go
+++ b/pkg/llm/openai/unit_test.go
@@ -49,7 +49,7 @@ func TestEnvOverride(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	t.Setenv("AI_CHAT_API_KEY", "token")
+	t.Setenv("OPENAI_API_KEY", "token")
 	t.Setenv("AICHAT_BASE_URL", srv.URL)
 	c := newUnitClient(srv, func(time.Duration) {})
 	s, err := c.Completion(context.Background(), llm.Request{Model: "m", Messages: []llm.Message{{Role: "user", Content: "q"}}})
@@ -70,7 +70,7 @@ func TestHTTPError(t *testing.T) {
 		http.Error(w, "fail", http.StatusBadRequest)
 	}))
 	defer srv.Close()
-	t.Setenv("AI_CHAT_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	t.Setenv("AICHAT_BASE_URL", srv.URL)
 	c := newUnitClient(srv, func(time.Duration) {})
 	_, err := c.Completion(context.Background(), llm.Request{Model: "m"})
@@ -93,7 +93,7 @@ func TestIgnoreNonDataLines(t *testing.T) {
 		}
 	}))
 	defer srv.Close()
-	t.Setenv("AI_CHAT_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	t.Setenv("AICHAT_BASE_URL", srv.URL)
 	c := newUnitClient(srv, func(time.Duration) {})
 	s, err := c.Completion(context.Background(), llm.Request{Model: "m", Messages: []llm.Message{{Role: "u", Content: "q"}}})
@@ -120,7 +120,7 @@ func TestInvalidJSON(t *testing.T) {
 		}
 	}))
 	defer srv.Close()
-	t.Setenv("AI_CHAT_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	t.Setenv("AICHAT_BASE_URL", srv.URL)
 	c := newUnitClient(srv, func(time.Duration) {})
 	s, err := c.Completion(context.Background(), llm.Request{Model: "m", Messages: []llm.Message{{Role: "u", Content: "q"}}})
@@ -144,7 +144,7 @@ func TestRetry(t *testing.T) {
 		}
 	}))
 	defer srv.Close()
-	t.Setenv("AI_CHAT_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	t.Setenv("AICHAT_BASE_URL", srv.URL)
 	first := true
 	slept := false
@@ -174,14 +174,14 @@ func TestNewFromConfig(t *testing.T) {
 	config.Reset()
 	dir := t.TempDir()
 	file := filepath.Join(dir, "c.yaml")
-	t.Setenv("AICHAT_OPENAI_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	if err := config.Load(file); err != nil {
 		t.Fatalf("load: %v", err)
 	}
 	if err := config.Set("openai_api_key", "cfg"); err != nil {
 		t.Fatalf("set: %v", err)
 	}
-	t.Setenv("AI_CHAT_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
 	c := New()
 	if c.key != "cfg" {
 		t.Fatalf("want cfg got %s", c.key)
@@ -200,7 +200,7 @@ func TestRecvScannerError(t *testing.T) {
 		}
 	}))
 	defer srv.Close()
-	t.Setenv("AI_CHAT_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	t.Setenv("AICHAT_BASE_URL", srv.URL)
 	c := newUnitClient(srv, func(time.Duration) {})
 	s, err := c.Completion(context.Background(), llm.Request{Model: "m", Messages: []llm.Message{{Role: "u", Content: "q"}}})
@@ -218,7 +218,7 @@ func TestRetryFails(t *testing.T) {
 		return nil, io.ErrUnexpectedEOF
 	})
 	client := &http.Client{Transport: rt}
-	t.Setenv("AI_CHAT_API_KEY", "k")
+	t.Setenv("OPENAI_API_KEY", "k")
 	c := New(WithHTTPClient(client), WithSleep(func(time.Duration) {}))
 	_, err := c.Completion(context.Background(), llm.Request{Model: "m"})
 	if err == nil {
@@ -228,10 +228,10 @@ func TestRetryFails(t *testing.T) {
 
 func TestNewDefaults(t *testing.T) {
 	config.Reset()
-	oldKey := os.Getenv("AI_CHAT_API_KEY")
+	oldKey := os.Getenv("OPENAI_API_KEY")
 	oldBase := os.Getenv("AICHAT_BASE_URL")
 	oldTimeout := os.Getenv("AICHAT_TIMEOUT")
-	if err := os.Setenv("AI_CHAT_API_KEY", "tok"); err != nil {
+	if err := os.Setenv("OPENAI_API_KEY", "tok"); err != nil {
 		t.Fatalf("setenv: %v", err)
 	}
 	if err := os.Setenv("AICHAT_BASE_URL", ""); err != nil {
@@ -241,7 +241,7 @@ func TestNewDefaults(t *testing.T) {
 		t.Fatalf("setenv: %v", err)
 	}
 	t.Cleanup(func() {
-		_ = os.Setenv("AI_CHAT_API_KEY", oldKey)
+		_ = os.Setenv("OPENAI_API_KEY", oldKey)
 		_ = os.Setenv("AICHAT_BASE_URL", oldBase)
 		_ = os.Setenv("AICHAT_TIMEOUT", oldTimeout)
 	})
@@ -258,16 +258,16 @@ func TestNewDefaults(t *testing.T) {
 }
 
 func TestNewTimeoutEnv(t *testing.T) {
-	oldKey := os.Getenv("AI_CHAT_API_KEY")
+	oldKey := os.Getenv("OPENAI_API_KEY")
 	oldTimeout := os.Getenv("AICHAT_TIMEOUT")
-	if err := os.Setenv("AI_CHAT_API_KEY", "tok"); err != nil {
+	if err := os.Setenv("OPENAI_API_KEY", "tok"); err != nil {
 		t.Fatalf("setenv: %v", err)
 	}
 	if err := os.Setenv("AICHAT_TIMEOUT", "5s"); err != nil {
 		t.Fatalf("setenv: %v", err)
 	}
 	t.Cleanup(func() {
-		_ = os.Setenv("AI_CHAT_API_KEY", oldKey)
+		_ = os.Setenv("OPENAI_API_KEY", oldKey)
 		_ = os.Setenv("AICHAT_TIMEOUT", oldTimeout)
 	})
 	c := New()
@@ -277,11 +277,11 @@ func TestNewTimeoutEnv(t *testing.T) {
 }
 
 func TestNewNilOptions(t *testing.T) {
-	oldKey := os.Getenv("AI_CHAT_API_KEY")
-	if err := os.Setenv("AI_CHAT_API_KEY", "tok"); err != nil {
+	oldKey := os.Getenv("OPENAI_API_KEY")
+	if err := os.Setenv("OPENAI_API_KEY", "tok"); err != nil {
 		t.Fatalf("setenv: %v", err)
 	}
-	t.Cleanup(func() { _ = os.Setenv("AI_CHAT_API_KEY", oldKey) })
+	t.Cleanup(func() { _ = os.Setenv("OPENAI_API_KEY", oldKey) })
 	c := New(WithHTTPClient(nil), WithSleep(nil))
 	if c.http == nil || c.sleep == nil {
 		t.Fatalf("nil not defaulted")

--- a/version_test.go
+++ b/version_test.go
@@ -35,7 +35,7 @@ func TestStampedVersion(t *testing.T) {
 		t.Fatalf("build: %v\n%s", err, out)
 	}
 	cmd := exec.Command(exe, "version")
-	cmd.Env = append(cmd.Env, "AICHAT_OPENAI_API_KEY=dummy")
+	cmd.Env = append(cmd.Env, "OPENAI_API_KEY=dummy")
 	out, err := cmd.Output()
 	if err != nil {
 		t.Fatalf("run: %v", err)


### PR DESCRIPTION
## Summary
- create a `defaultLLM` sentinel and use the real OpenAI client when the
  default mock is still set

## Testing
- `npm install`
- `npm audit`
- `make docs`
- `addlicense -check $(git ls-files '*.go')`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_684859b6bf048326bd3f7ee01d32fc55