### PR TITLE
Add wizard alias command

### DIFF
--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -16,38 +16,25 @@
 package cmd
 
 import (
-	"context"
-	"fmt"
-	"sort"
-
-	"github.com/jalsarraf0/ai-chat-cli/pkg/llm"
-	"github.com/spf13/cobra"
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
 )
 
-func newModelsCmd(c llm.Client) *cobra.Command {
-	var list bool
-	cmd := &cobra.Command{
-		Use:   "models",
-		Short: "List available models",
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			if !list {
-				list = true
-			}
-			if list {
-				models, err := c.ListModels(context.Background())
-				if err != nil {
-					return err
-				}
-				sort.Strings(models)
-				for _, m := range models {
-					if _, err := fmt.Fprintln(cmd.OutOrStdout(), m); err != nil {
-						return err
-					}
-				}
-			}
-			return nil
-		},
+func TestInitRunsScript(t *testing.T) {
+	script := filepath.Join(t.TempDir(), "setup.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho ok"), 0o755); err != nil {
+		t.Fatalf("write: %v", err)
 	}
-	cmd.Flags().BoolVar(&list, "list", false, "list models")
-	return cmd
+	setupScript = script
+	cmd := newInitCmd()
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if out.String() != "ok\n" {
+		t.Fatalf("out=%q", out.String())
+	}
 }

--- a/cmd/models_test.go
+++ b/cmd/models_test.go
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -113,6 +113,8 @@ func newRootCmd() *cobra.Command {
 	cmd.AddCommand(newConfigCmd())
 	cmd.AddCommand(newLoginCmd())
 	cmd.AddCommand(newModelsCmd(llmClient))
+	cmd.AddCommand(newInitCmd())
+	cmd.AddCommand(newWizardCmd())
 	cmd.AddCommand(newTuiCmd())
 	cmd.AddCommand(newAskCmd())
 	cmd.AddCommand(newHealthcheckCmd())

--- a/cmd/wizard.go
+++ b/cmd/wizard.go
@@ -15,39 +15,19 @@
 
 package cmd
 
-import (
-	"context"
-	"fmt"
-	"sort"
+import "github.com/spf13/cobra"
 
-	"github.com/jalsarraf0/ai-chat-cli/pkg/llm"
-	"github.com/spf13/cobra"
-)
-
-func newModelsCmd(c llm.Client) *cobra.Command {
-	var list bool
-	cmd := &cobra.Command{
-		Use:   "models",
-		Short: "List available models",
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			if !list {
-				list = true
-			}
-			if list {
-				models, err := c.ListModels(context.Background())
-				if err != nil {
-					return err
-				}
-				sort.Strings(models)
-				for _, m := range models {
-					if _, err := fmt.Fprintln(cmd.OutOrStdout(), m); err != nil {
-						return err
-					}
-				}
-			}
-			return nil
+func newWizardCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "wizard",
+		Short: "Alias for init",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			initCmd := newInitCmd()
+			initCmd.SetArgs(args)
+			initCmd.SetOut(cmd.OutOrStdout())
+			initCmd.SetErr(cmd.ErrOrStderr())
+			initCmd.SilenceUsage = true
+			return initCmd.Execute()
 		},
 	}
-	cmd.Flags().BoolVar(&list, "list", false, "list models")
-	return cmd
 }

--- a/cmd/wizard_test.go
+++ b/cmd/wizard_test.go
@@ -16,38 +16,25 @@
 package cmd
 
 import (
-	"context"
-	"fmt"
-	"sort"
-
-	"github.com/jalsarraf0/ai-chat-cli/pkg/llm"
-	"github.com/spf13/cobra"
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
 )
 
-func newModelsCmd(c llm.Client) *cobra.Command {
-	var list bool
-	cmd := &cobra.Command{
-		Use:   "models",
-		Short: "List available models",
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			if !list {
-				list = true
-			}
-			if list {
-				models, err := c.ListModels(context.Background())
-				if err != nil {
-					return err
-				}
-				sort.Strings(models)
-				for _, m := range models {
-					if _, err := fmt.Fprintln(cmd.OutOrStdout(), m); err != nil {
-						return err
-					}
-				}
-			}
-			return nil
-		},
+func TestWizardAlias(t *testing.T) {
+	script := filepath.Join(t.TempDir(), "setup.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho hi"), 0o755); err != nil {
+		t.Fatalf("write: %v", err)
 	}
-	cmd.Flags().BoolVar(&list, "list", false, "list models")
-	return cmd
+	setupScript = script
+	cmd := newWizardCmd()
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if out.String() != "hi\n" {
+		t.Fatalf("out=%q", out.String())
+	}
 }


### PR DESCRIPTION
## Summary
- add `init` command that invokes the setup script
- add new `wizard` command as alias to `init`
- wire new commands into root
- cover new commands with unit tests
- ensure existing model files carry license headers

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`
- `goreleaser release --snapshot --clean`


------
https://chatgpt.com/codex/tasks/task_e_684913c6ec0c8326b404e278de98fdca