### PR TITLE
Add static model list and default selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Run `ai-chat --help` for available commands. Use `ai-chat <command> --help` for 
 | `plugins`  | Manage plug‑ins       |
 | `history`  | List/search old chats |
 | `export`   | Save chats            |
+| `models`   | List available models |
 | `config`   | Show or edit config   |
 | `version`  | Build info            |
 
@@ -156,7 +157,7 @@ Default file `~/.config/ai-chat/ai-chat.yaml`:
 
 ```yaml
 provider: openai
-model: gpt-4o
+model: gpt-4.1-nano
 temperature: 0.6
 context_window: 16
 plugins_dir: ~/.config/ai-chat/plugins

--- a/cmd/ask_test.go
+++ b/cmd/ask_test.go
@@ -60,6 +60,7 @@ type errorClient struct{}
 func (errorClient) Completion(_ context.Context, _ llm.Request) (llm.Stream, error) {
 	return nil, io.EOF
 }
+func (errorClient) ListModels(context.Context) ([]string, error) { return nil, nil }
 
 func TestRootAskError(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "k")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"reflect"
 	"strings"
@@ -88,7 +87,6 @@ func newRootCmd() *cobra.Command {
 				}
 				return err
 			}
-			log.Printf("INFO: config %s", config.Path())
 			if reflect.DeepEqual(llmClient, defaultLLM) {
 				llmClient = openai.New()
 			}
@@ -112,6 +110,7 @@ func newRootCmd() *cobra.Command {
 	cmd.AddCommand(newAssetsCmd())
 	cmd.AddCommand(newConfigCmd())
 	cmd.AddCommand(newLoginCmd())
+	cmd.AddCommand(newModelsCmd(llmClient))
 	cmd.AddCommand(newTuiCmd())
 	cmd.AddCommand(newAskCmd())
 	cmd.AddCommand(newHealthcheckCmd())

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -91,3 +91,20 @@ func TestExecuteFailure(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestRootModels(t *testing.T) {
+	llmClient = stubLLM{models: []string{"m1"}}
+	t.Setenv("OPENAI_API_KEY", "k")
+	config.Reset()
+	cfg := filepath.Join(t.TempDir(), "c.yaml")
+	cmd := newRootCmd()
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"--config", cfg, "models"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("models: %v", err)
+	}
+	if out.String() != "m1\n" {
+		t.Fatalf("out=%q", out.String())
+	}
+}

--- a/cmd/testhelpers_test.go
+++ b/cmd/testhelpers_test.go
@@ -15,8 +15,24 @@
 
 package cmd
 
-import "io"
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/jalsarraf0/ai-chat-cli/pkg/llm"
+)
 
 type failWriter struct{}
 
 func (failWriter) Write([]byte) (int, error) { return 0, io.ErrClosedPipe }
+
+type stubLLM struct{ models []string }
+
+func (s stubLLM) Completion(context.Context, llm.Request) (llm.Stream, error) { return nil, nil }
+func (s stubLLM) ListModels(context.Context) ([]string, error)                { return s.models, nil }
+
+type errLLM struct{}
+
+func (errLLM) Completion(context.Context, llm.Request) (llm.Stream, error) { return nil, nil }
+func (errLLM) ListModels(context.Context) ([]string, error)                { return nil, errors.New("fail") }

--- a/docs/config.md
+++ b/docs/config.md
@@ -9,6 +9,6 @@ The CLI stores settings in a YAML file located at:
 Environment variables with prefix `AICHAT_` override file values. Keys include:
 
 - `openai_api_key` – API token (required, env var `OPENAI_API_KEY`)
-- `model` – allowed values `gpt-4`, `gpt-3.5-turbo`
+- `model` – default `gpt-4.1-nano`; run `ai-chat models` for the full list
 
 Use `ai-chat config show` to print the config file path and contents, `ai-chat config set <key> <value>` to change a value, or `ai-chat config edit` to open the file in your editor.

--- a/docs/installer.md
+++ b/docs/installer.md
@@ -2,30 +2,30 @@
 
 
 The `install.sh` script downloads and builds **ai-chat-cli**, copies the binary to `/usr/local/bin` and prompts for your
-API key. The value is saved to `$XDG_CONFIG_HOME/ai-chat/ai-chat.yaml` along with a default model of `gpt-4o`.
+API key. The value is saved to `$XDG_CONFIG_HOME/ai-chat/ai-chat.yaml` along with a default model of `gpt-4.1-nano`.
 
 
 
 The `install.sh` script downloads and builds **ai-chat-cli**, copies the binary to `/usr/local/bin` and prompts for your
-API key. The value is saved to `$XDG_CONFIG_HOME/ai-chat/ai-chat.yaml` along with a default model of `gpt-4o`.
+API key. The value is saved to `$XDG_CONFIG_HOME/ai-chat/ai-chat.yaml` along with a default model of `gpt-4.1-nano`.
 
 
 
 The `install.sh` script downloads and builds **ai-chat-cli**, copies the binary to `/usr/local/bin` and prompts for your
-API key. The value is saved to `$XDG_CONFIG_HOME/ai-chat/ai-chat.yaml` along with a default model of `gpt-4o`.
+API key. The value is saved to `$XDG_CONFIG_HOME/ai-chat/ai-chat.yaml` along with a default model of `gpt-4.1-nano`.
 
 
 The `install.sh` script downloads and builds **ai-chat-cli**, copies the binary to `/usr/local/bin` and prompts for your
-API key. The value is saved to `$XDG_CONFIG_HOME/ai-chat/ai-chat.yaml` along with a default model of `gpt-4o`.
+API key. The value is saved to `$XDG_CONFIG_HOME/ai-chat/ai-chat.yaml` along with a default model of `gpt-4.1-nano`.
 
 
 
 The `install.sh` script downloads and builds **ai-chat-cli**, copies the binary to `/usr/local/bin` and prompts for your
-API key. The value is saved to `$XDG_CONFIG_HOME/ai-chat/ai-chat.yaml` along with a default model of `gpt-4o`.
+API key. The value is saved to `$XDG_CONFIG_HOME/ai-chat/ai-chat.yaml` along with a default model of `gpt-4.1-nano`.
 
 The `install.sh` script downloads and builds **ai-chat-cli**, then prompts for your
 API key. The value is saved to
-`$XDG_CONFIG_HOME/ai-chat/ai-chat.yaml` along with a default model of `gpt-4o`.
+`$XDG_CONFIG_HOME/ai-chat/ai-chat.yaml` along with a default model of `gpt-4.1-nano`.
 
 
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -107,8 +107,35 @@ func All() map[string]any { return v.AllSettings() }
 func defaultPath() string { return defaultPathImpl() }
 
 var allowedModels = map[string]struct{}{
-	"gpt-4":         {},
-	"gpt-3.5-turbo": {},
+	"gpt-4o":                 {},
+	"gpt-4o-mini":            {},
+	"gpt-4o-audio-preview":   {},
+	"gpt-4o-2024-05-13":      {},
+	"gpt-4.1":                {},
+	"gpt-4.1-mini":           {},
+	"gpt-4.1-nano":           {},
+	"gpt-4.1-2025-04-14":     {},
+	"gpt-4":                  {},
+	"gpt-4-32k":              {},
+	"gpt-4-turbo":            {},
+	"gpt-4-turbo-preview":    {},
+	"gpt-4-vision-preview":   {},
+	"gpt-4-0314":             {},
+	"gpt-4-0613":             {},
+	"gpt-4-0125-preview":     {},
+	"gpt-3.5-turbo":          {},
+	"gpt-3.5-turbo-16k":      {},
+	"gpt-3.5-turbo-0125":     {},
+	"gpt-3.5-turbo-1106":     {},
+	"text-embedding-3-large": {},
+	"text-embedding-3-small": {},
+	"text-embedding-ada-002": {},
+	"whisper-1":              {},
+	"dall-e-3":               {},
+	"moderation-latest":      {},
+	"moderation-v1":          {},
+	"gpt-4o-nano":            {},
+	"gpt-image-1":            {},
 }
 
 func validate() error {

--- a/pkg/llm/llm.go
+++ b/pkg/llm/llm.go
@@ -45,4 +45,6 @@ type Stream interface {
 // Client sends completion requests to a language model.
 type Client interface {
 	Completion(ctx context.Context, req Request) (Stream, error)
+	// ListModels returns all available model identifiers.
+	ListModels(ctx context.Context) ([]string, error)
 }

--- a/pkg/llm/mock/mock.go
+++ b/pkg/llm/mock/mock.go
@@ -26,16 +26,22 @@ import (
 // Client returns predetermined tokens.
 type Client struct {
 	tokens []string
+	models []string
 }
 
 // New creates a mock client that streams the given tokens.
 func New(tokens ...string) Client {
-	return Client{tokens: tokens}
+	return Client{tokens: tokens, models: []string{"gpt-4.1-nano", "gpt-3.5-turbo"}}
 }
 
 // Completion returns a stream of predetermined tokens.
 func (c Client) Completion(_ context.Context, _ llm.Request) (llm.Stream, error) {
 	return &stream{tokens: c.tokens}, nil
+}
+
+// ListModels returns a fixed set of model names.
+func (c Client) ListModels(context.Context) ([]string, error) {
+	return c.models, nil
 }
 
 type stream struct {

--- a/pkg/llm/openai/openai.go
+++ b/pkg/llm/openai/openai.go
@@ -25,12 +25,45 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/jalsarraf0/ai-chat-cli/pkg/config"
 	"github.com/jalsarraf0/ai-chat-cli/pkg/llm"
 )
+
+var models = []string{
+	"gpt-4o",
+	"gpt-4o-mini",
+	"gpt-4o-audio-preview",
+	"gpt-4o-2024-05-13",
+	"gpt-4.1",
+	"gpt-4.1-mini",
+	"gpt-4.1-nano",
+	"gpt-4.1-2025-04-14",
+	"gpt-4",
+	"gpt-4-32k",
+	"gpt-4-turbo",
+	"gpt-4-turbo-preview",
+	"gpt-4-vision-preview",
+	"gpt-4-0314",
+	"gpt-4-0613",
+	"gpt-4-0125-preview",
+	"gpt-3.5-turbo",
+	"gpt-3.5-turbo-16k",
+	"gpt-3.5-turbo-0125",
+	"gpt-3.5-turbo-1106",
+	"text-embedding-3-large",
+	"text-embedding-3-small",
+	"text-embedding-ada-002",
+	"whisper-1",
+	"dall-e-3",
+	"moderation-latest",
+	"moderation-v1",
+	"gpt-4o-nano",
+	"gpt-image-1",
+}
 
 // Option configures a Client.
 type Option func(*Client)
@@ -166,4 +199,12 @@ func (s *stream) Recv() (llm.Response, error) {
 		return llm.Response{}, err
 	}
 	return llm.Response{}, io.EOF
+}
+
+// ListModels returns the known OpenAI model identifiers.
+func (c Client) ListModels(context.Context) ([]string, error) {
+	out := make([]string, len(models))
+	copy(out, models)
+	sort.Strings(out)
+	return out, nil
 }

--- a/pkg/llm/openai/unit_test.go
+++ b/pkg/llm/openai/unit_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -285,5 +286,30 @@ func TestNewNilOptions(t *testing.T) {
 	c := New(WithHTTPClient(nil), WithSleep(nil))
 	if c.http == nil || c.sleep == nil {
 		t.Fatalf("nil not defaulted")
+	}
+}
+
+func TestListModels(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "k")
+	c := New()
+	models, err := c.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(models) == 0 {
+		t.Fatalf("no models returned")
+	}
+	if sort.StringsAreSorted(models) == false {
+		t.Fatalf("models not sorted")
+	}
+	found := false
+	for _, m := range models {
+		if m == "gpt-4.1-nano" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("gpt-4.1-nano missing: %v", models)
 	}
 }

--- a/scripts/embedgen_test.go
+++ b/scripts/embedgen_test.go
@@ -17,10 +17,53 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
-func TestMainRun(t *testing.T) {
+func copyDir(dst, src string) error {
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		ds := filepath.Join(dst, e.Name())
+		ss := filepath.Join(src, e.Name())
+		if e.IsDir() {
+			if err := os.MkdirAll(ds, 0o755); err != nil {
+				return err
+			}
+			if err := copyDir(ds, ss); err != nil {
+				return err
+			}
+		} else {
+			b, err := os.ReadFile(ss)
+			if err != nil {
+				return err
+			}
+			if err := os.WriteFile(ds, b, 0o644); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func TestRunSuccess(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(".."); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(cwd) }()
+	if err := run("internal/assets"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMainFunction(t *testing.T) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)
@@ -30,4 +73,74 @@ func TestMainRun(t *testing.T) {
 	}
 	defer func() { _ = os.Chdir(cwd) }()
 	main()
+}
+
+func TestMainFunctionError(t *testing.T) {
+	tmp := t.TempDir()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(cwd) }()
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic")
+		}
+	}()
+	main()
+}
+
+func TestRunMissingDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	err := run(filepath.Join(tmpDir, "internal/assets"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestRunReadError(t *testing.T) {
+	tmpDir := t.TempDir()
+	// copy assets to tmpDir
+	src := filepath.Join("..", "internal", "assets")
+	dst := filepath.Join(tmpDir, "internal", "assets")
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := copyDir(dst, src); err != nil {
+		t.Fatal(err)
+	}
+	badFile := filepath.Join(dst, "templates", "default.tmpl")
+	if err := os.Remove(badFile); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(badFile, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = os.Remove(badFile)
+		// restore original file
+		orig := filepath.Join(src, "templates", "default.tmpl")
+		b, _ := os.ReadFile(orig)
+		_ = os.WriteFile(badFile, b, 0o644)
+	}()
+	if err := run(dst); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestRunCreateError(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "internal", "assets")
+	if err := os.MkdirAll(filepath.Join(tmpDir, "internal"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filePath, []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := run(filePath); err == nil {
+		t.Fatal("expected error")
+	}
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,15 @@ while [ "$#" -gt 0 ]; do
     esac
 done
 
+read -rp "Install prefix [$PREFIX]: " ans || true
+if [ -n "$ans" ]; then
+    PREFIX="$ans"
+fi
+read -rp "Proceed installing to $PREFIX? [Y/n]: " ans || true
+case "$ans" in
+    n|N) echo "Cancelled"; exit 1;;
+esac
+
 pkg_install() {
     if command -v apt-get >/dev/null 2>&1; then
         sudo apt-get update -y && sudo apt-get install -y "$@"
@@ -44,6 +53,11 @@ OPENAI_API_KEY=${OPENAI_API_KEY:-}
 if [ -z "$OPENAI_API_KEY" ]; then
     read -rp "Enter OPENAI_API_KEY (leave blank to edit later): " OPENAI_API_KEY || true
 fi
+MODEL="gpt-4.1-nano"
+read -rp "Default model [$MODEL]: " ans || true
+if [ -n "$ans" ]; then
+    MODEL="$ans"
+fi
 
 echo "-- building ai-chat..."
 go install ./cmd/ai-chat
@@ -64,7 +78,7 @@ mkdir -p "$config_dir"
 if [ ! -f "$config_file" ]; then
     cat >"$config_file" <<EOF
 openai_api_key: $OPENAI_API_KEY
-model: gpt-4
+model: $MODEL
 EOF
     echo "Created $config_file. Add your API key if empty." >&2
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -2,4 +2,5 @@
 set -euo pipefail
 # Wrapper script to run the interactive installer regardless of cwd
 SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+echo "Running ai-chat-cli setup. Press Ctrl+C to cancel." >&2
 exec "${SCRIPT_DIR}/scripts/install.sh" "$@"


### PR DESCRIPTION
## Summary
- prompt for API key and model in setup script
- set default model to `gpt-4.1-nano` in docs and installer
- allow full list of OpenAI models in config validation
- return static model list from OpenAI client
- update tests for new model listing behaviour
- remove noisy config logging
- add missing license headers for the models command

## Testing
- `npm install`
- `npm audit --production`
- `addlicense -check $(git ls-files '*.go')`
- `make docs`
- `golangci-lint run ./...`
- `staticcheck ./...`
- `go vet ./...`
- `gosec ./...` *(failed: runtime panic)*
- `govulncheck ./...`
- `goreleaser release --snapshot --clean --skip=publish --skip=docker --skip=sign` *(fails: only version 1 config supported)*
- `go test ./... -coverprofile=coverage.out`
- `go tool cover -func=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_6848ffb64d84832694c6b397b905e12d