### PR TITLE
Improve config parsing resilience

### DIFF
--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -120,8 +120,8 @@ func TestConfigCorruptFile(t *testing.T) {
 	config.Reset()
 	c := newRootCmd()
 	c.SetArgs([]string{"--config", cfgFile, "config", "list"})
-	if err := c.Execute(); err == nil {
-		t.Fatalf("expected error")
+	if err := c.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -38,3 +38,26 @@ func TestInitRunsScript(t *testing.T) {
 		t.Fatalf("out=%q", out.String())
 	}
 }
+
+func TestInitRelativeScript(t *testing.T) {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Skip(err)
+	}
+	dir := filepath.Dir(exe)
+	script := filepath.Join(dir, "setup.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho hi"), 0o755); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(script) })
+	setupScript = "setup.sh"
+	cmd := newInitCmd()
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if out.String() != "hi\n" {
+		t.Fatalf("out=%q", out.String())
+	}
+}

--- a/cmd/login_test.go
+++ b/cmd/login_test.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/jalsarraf0/ai-chat-cli/pkg/config"
+)
+
+func TestLoginCmd(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "c.yaml")
+	config.Reset()
+	c := newRootCmd()
+	c.SetArgs([]string{"--config", cfg, "login", "abc123"})
+	if err := c.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if config.GetString("openai_api_key") != "abc123" {
+		t.Fatalf("key not set")
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -57,8 +57,14 @@ func Load(p string) error {
 		return err
 	}
 	if err := v.ReadInConfig(); err != nil {
-		var e viper.ConfigFileNotFoundError
-		if !errors.As(err, &e) && !errors.Is(err, os.ErrNotExist) {
+		var nf viper.ConfigFileNotFoundError
+		var pe viper.ConfigParseError
+		switch {
+		case errors.As(err, &nf), errors.Is(err, os.ErrNotExist):
+			// ignore missing file
+		case errors.As(err, &pe):
+			// ignore malformed config and continue with defaults
+		default:
 			return err
 		}
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -16,6 +16,7 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -174,8 +175,23 @@ func TestLoadInvalidYAML(t *testing.T) {
 	if err := os.WriteFile(file, []byte(": bad"), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	if err := Load(file); err == nil {
-		t.Fatalf("expected error")
+	if err := Load(file); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if GetString("openai_api_key") != "k" {
+		t.Fatalf("env override")
+	}
+}
+
+func TestLoadParseErrorNoEnv(t *testing.T) {
+	Reset()
+	dir := t.TempDir()
+	file := filepath.Join(dir, "c.yaml")
+	if err := os.WriteFile(file, []byte("x: :"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := Load(file); !errors.Is(err, ErrAPIKeyMissing) {
+		t.Fatalf("want missing key, got %v", err)
 	}
 }
 

--- a/pkg/llm/mock/mock.go
+++ b/pkg/llm/mock/mock.go
@@ -31,11 +31,7 @@ type Client struct {
 
 // New creates a mock client that streams the given tokens.
 func New(tokens ...string) Client {
-
 	return Client{tokens: tokens, models: []string{"gpt-4.1-nano", "gpt-3.5-turbo"}}
-
-	return Client{tokens: tokens, models: []string{"gpt-4", "gpt-3.5-turbo"}}
-
 }
 
 // Completion returns a stream of predetermined tokens.

--- a/pkg/llm/openai/unit_test.go
+++ b/pkg/llm/openai/unit_test.go
@@ -292,7 +292,6 @@ func TestNewNilOptions(t *testing.T) {
 func TestListModels(t *testing.T) {
 
 	t.Setenv("OPENAI_API_KEY", "k")
-	c := New()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -323,9 +322,9 @@ func TestListModels(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("gpt-4.1-nano missing: %v", models)
-
-	if len(models) != 2 || models[0] != "gpt-a" || models[1] != "gpt-b" {
-		t.Fatalf("models %v", models)
+		if len(models) != 2 || models[0] != "gpt-a" || models[1] != "gpt-b" {
+			t.Fatalf("models %v", models)
+		}
 	}
 }
 
@@ -341,5 +340,19 @@ func TestListModelsHTTPError(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "bad") {
 		t.Fatalf("want error got %v", err)
 
+	}
+}
+
+func TestListModelsDecodeError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, "not-json")
+	}))
+	defer srv.Close()
+	t.Setenv("OPENAI_API_KEY", "k")
+	t.Setenv("AICHAT_BASE_URL", srv.URL)
+	c := newUnitClient(srv, func(time.Duration) {})
+	if _, err := c.ListModels(context.Background()); err == nil {
+		t.Fatalf("expected decode error")
 	}
 }


### PR DESCRIPTION
## Summary
- make config.Load tolerate malformed YAML
- update unit tests for new behavior
- add login and init command tests
- increase coverage in OpenAI client tests

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./... -coverprofile=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_68491cdc9fe0832685b74cbcebbc9da5