### PR TITLE
Implement doc skip workflow

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+repo_root=$(git rev-parse --show-toplevel)
+if go run -tags tools "$repo_root/tools/ci-sieve" >/dev/null; then
+  echo "Docs-only commit: skipping CI pipeline trigger" >&2
+fi

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+repo_root=$(git rev-parse --show-toplevel)
+if go run -tags tools "$repo_root/tools/ci-sieve" >/dev/null; then
+  sed -i '1s/$/ [skip ci]/' "$1"
+fi

--- a/.github/workflows/ci-final.yml
+++ b/.github/workflows/ci-final.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   GO_BIN: $HOME/go/bin
-  COVERAGE_THRESHOLD: 90
+  COVERAGE_THRESHOLD: 93
   TRIVY_VERSION: 0.63.0
   GOLANGCI_VERSION: 2.1.6
   GOSEC_VERSION: v2.19.0
@@ -38,10 +38,32 @@ jobs:
             ci_final:
               - '.github/workflows/ci-final.yml'
 
+  pipeline-guard:
+    runs-on: ubuntu-latest
+    needs: [changes]
+    outputs:
+      docs_only: ${{ steps.determine.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - id: determine
+        run: |
+          BASE=${{ github.event.pull_request.base.sha || github.event.before }}
+          if [ -z "$BASE" ]; then BASE=$(git rev-parse HEAD^); fi
+          if go run -tags tools ./tools/ci-sieve -range "$BASE..HEAD"; then
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          fi
+
   # 1 ── Lint ────────────────────────────────────────────────
   lint:
-    needs: [changes]
-    if: needs.changes.outputs.ci_final != 'true'
+    needs: [changes, pipeline-guard]
+    if: needs.changes.outputs.ci_final != 'true' && needs.pipeline-guard.outputs.docs_only != 'true'
     runs-on: [self-hosted, linux]
     steps:
       - uses: actions/checkout@v4
@@ -53,8 +75,8 @@ jobs:
 
   # 2 ── Docs ────────────────────────────────────────────────
   docs:
-    needs: [changes, lint]
-    if: needs.changes.outputs.ci_final != 'true'
+    needs: [changes, pipeline-guard, lint]
+    if: needs.changes.outputs.ci_final != 'true' && needs.pipeline-guard.outputs.docs_only != 'true'
     runs-on: [self-hosted, linux]
     steps:
       - uses: actions/checkout@v4
@@ -73,8 +95,8 @@ jobs:
 
   # 3 ── Security ───────────────────────────────────────────
   security:
-    needs: [changes, lint]
-    if: needs.changes.outputs.ci_final != 'true'
+    needs: [changes, pipeline-guard, lint]
+    if: needs.changes.outputs.ci_final != 'true' && needs.pipeline-guard.outputs.docs_only != 'true'
     runs-on: [self-hosted, linux]
     steps:
       - uses: actions/checkout@v4
@@ -100,8 +122,8 @@ jobs:
 
   # 4 ── Tests & Coverage ───────────────────────────────────
   test:
-    needs: [changes, lint, docs]
-    if: needs.changes.outputs.ci_final != 'true'
+    needs: [changes, pipeline-guard, lint, docs]
+    if: needs.changes.outputs.ci_final != 'true' && needs.pipeline-guard.outputs.docs_only != 'true'
     runs-on: [self-hosted, linux]
     steps:
       - uses: actions/checkout@v4
@@ -119,8 +141,8 @@ jobs:
 
   # 5 ── Verify go.sum ──────────────────────────────────────
   verify-go-sum:
-    needs: [changes, test]
-    if: needs.changes.outputs.ci_final != 'true'
+    needs: [changes, pipeline-guard, test]
+    if: needs.changes.outputs.ci_final != 'true' && needs.pipeline-guard.outputs.docs_only != 'true'
     runs-on: [self-hosted, linux]
     steps:
       - uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -44,15 +44,9 @@ coverage:
 .PHONY: coverage
 
 coverage-gate:
-
-	@pct=$$(go tool cover -func=coverage.out | awk '/^total:/ {gsub("%","" );print $$3}'); \
-	th=93; if echo "$$pct < $$th" | bc -l | grep -q 1; then \
-	echo "::error::coverage < $$th% (got $$pct%)"; exit 1; fi
-	
-
-       @pct=$$(go tool cover -func=coverage.out | awk '/^total:/ {gsub("%","" );print $$3}'); \
-       if [ $${pct%.*} -lt 90 ]; then \
-       echo "::error::coverage < 90% (got $${pct}%)"; exit 1; fi
+        @pct=$$(go tool cover -func=coverage.out | awk '/^total:/ {gsub("%","" );print $$3}'); \
+        th=93; if echo "$$pct < $$th" | bc -l | grep -q 1; then \
+            echo "::error::coverage < $$th% (got $$pct%)"; exit 1; fi
 
 install-hugo:
 	./scripts/install_hugo.sh

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AI‑Chat‑CLI 🤖
 
 [![CI](https://img.shields.io/github/actions/workflow/status/jalsarraf0/ai-chat-cli/ci-final.yml?label=CI&logo=githubactions&logoColor=white&style=flat-square)](https://github.com/jalsarraf0/ai-chat-cli/actions/workflows/ci-final.yml)
-[![Coverage 95%](https://img.shields.io/badge/Coverage-95%25-brightgreen?style=flat-square&logo=codecov&logoColor=white)](https://codecov.io/gh/jalsarraf0/ai-chat-cli)
+[![Coverage 93%](https://img.shields.io/badge/Coverage-93%25-brightgreen?style=flat-square&logo=codecov&logoColor=white)](https://codecov.io/gh/jalsarraf0/ai-chat-cli)
 [![Go Report: Clean](https://img.shields.io/badge/Go%20Report-Clean-brightgreen?style=flat-square&logo=go&logoColor=white)](https://goreportcard.com/report/github.com/jalsarraf0/ai-chat-cli)
 [![Release](https://img.shields.io/github/v/release/jalsarraf0/ai-chat-cli?include_prereleases&label=Release&logo=github&logoColor=white&style=flat-square)](https://github.com/jalsarraf0/ai-chat-cli/releases)
 [![License MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](https://github.com/jalsarraf0/ai-chat-cli/blob/dev/LICENSE)
@@ -186,7 +186,7 @@ Any executable placed in the plug‑ins directory becomes a slash‑command: `/h
 | Job          | Tool               | Gate           |
 | ------------ | ------------------ | -------------- |
 | **Lint**     | golangci‑lint      | no warnings    |
-| **Unit**     | `go test -race`    | 90 %+ coverage |
+| **Unit**     | `go test -race`    | 93 %+ coverage |
 | **Security** | gosec, govulncheck | zero criticals |
 
 ---
@@ -206,6 +206,7 @@ make coverage     # HTML coverage report
 2. Write tests & code
 3. `make` must pass
 4. Open PR 🚀
+5. Docs-only changes auto-add `[skip ci]` via git hook
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,6 +69,13 @@ make build
 Tag a commit. CI builds artefacts, generates an SBOM, signs with Cosign,
 and publishes to GitHub and an OCI registry.
 
+## Intelligent CI Skip
+
+Commits that only modify documentation are detected automatically. A local
+`prepare-commit-msg` hook appends `[skip ci]` to the message, and the
+`pipeline-guard` job exits early so runners stay idle. Any code change runs the
+full suite with a **93 %** coverage gate.
+
 ## Compliance Mapping
 
 | NIST 800-53 Control | Implementation |

--- a/pkg/llm/openai/openai.go
+++ b/pkg/llm/openai/openai.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package openai implements an OpenAI client.
+// Package openai implements an OpenAI-based Client.
 package openai
 
 import (
@@ -216,7 +216,6 @@ func (c Client) ListModels(ctx context.Context) ([]string, error) {
 	for _, m := range defaultModels {
 		uniq[m] = struct{}{}
 	}
-
 	if c.key == "" {
 		return sorted(uniq), nil
 	}
@@ -243,30 +242,9 @@ func (c Client) ListModels(ctx context.Context) ([]string, error) {
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
 		return sorted(uniq), err
 	}
-
 	for _, m := range data.Data {
 		uniq[m.ID] = struct{}{}
 	}
-
-
-	for _, m := range data.Data {
-		uniq[m.ID] = struct{}{}
-
-	uniq := map[string]struct{}{}
-	for _, m := range defaultModels {
-		uniq[m] = struct{}{}
-	}
-	for _, m := range data.Data {
-		uniq[m.ID] = struct{}{}
-	}
-
-	models := make([]string, 0, len(uniq))
-	for id := range uniq {
-		models = append(models, id)
-
-	}
-
 
 	return sorted(uniq), nil
-
 }

--- a/tools/ci-sieve/main.go
+++ b/tools/ci-sieve/main.go
@@ -1,0 +1,134 @@
+//go:build tools
+
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var diffRange string
+
+func init() {
+	flag.StringVar(&diffRange, "range", "", "git diff range (e.g. base..HEAD)")
+}
+
+func main() {
+	flag.Parse()
+	files, err := changedFiles()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if len(files) == 0 {
+		fmt.Println("no_changes")
+		return
+	}
+	docsOnly := true
+	for _, f := range files {
+		if isDocPath(f) {
+			continue
+		}
+		if !commentOnly(f) {
+			docsOnly = false
+			break
+		}
+	}
+	if docsOnly {
+		fmt.Println("docs_only")
+		return
+	}
+	fmt.Println("code_change")
+	os.Exit(1)
+}
+
+func gitDiffArgs() []string {
+	if diffRange != "" {
+		return []string{"diff", diffRange}
+	}
+	return []string{"diff", "--cached"}
+}
+
+func changedFiles() ([]string, error) {
+	args := append(gitDiffArgs(), "--name-only")
+	out, err := exec.Command("git", args...).Output()
+	if err != nil {
+		return nil, fmt.Errorf("git diff: %w", err)
+	}
+	lines := strings.Fields(string(out))
+	return lines, nil
+}
+
+func isDocPath(p string) bool {
+	if strings.HasPrefix(p, "docs/") {
+		return true
+	}
+	switch filepath.Ext(p) {
+	case ".md", ".rst", ".adoc", ".txt":
+		return true
+	}
+	return false
+}
+
+var commentPrefixes = map[string][]string{
+	".go":   {"//"},
+	".sh":   {"#"},
+	".bash": {"#"},
+	".py":   {"#"},
+	".rb":   {"#"},
+	".yaml": {"#"},
+	".yml":  {"#"},
+	".toml": {"#"},
+	".c":    {"//", "/*"},
+	".cpp":  {"//", "/*"},
+	".js":   {"//"},
+	".ts":   {"//"},
+}
+
+var patchLine = regexp.MustCompile(`^\+(.*)`)
+
+func commentOnly(path string) bool {
+	args := gitDiffArgs()
+	args = append(args, "-U0", path)
+	cmd := exec.Command("git", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	scanner := bufio.NewScanner(strings.NewReader(string(out)))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---") || strings.HasPrefix(line, "diff") || strings.HasPrefix(line, "@@") {
+			continue
+		}
+		m := patchLine.FindStringSubmatch(line)
+		if len(m) != 2 {
+			continue
+		}
+		content := strings.TrimSpace(m[1])
+		if content == "" {
+			continue
+		}
+		if isCommentLine(path, content) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func isCommentLine(path, line string) bool {
+	for _, p := range commentPrefixes[filepath.Ext(path)] {
+		if strings.HasPrefix(line, p) {
+			return true
+		}
+	}
+	// generic comment characters
+	return strings.HasPrefix(line, "#") || strings.HasPrefix(line, "//")
+}

--- a/tools/ci-sieve/main_test.go
+++ b/tools/ci-sieve/main_test.go
@@ -1,0 +1,144 @@
+//go:build tools
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsDocPath(t *testing.T) {
+	cases := map[string]bool{
+		"docs/readme.md": true,
+		"README.md":      true,
+		"file.txt":       true,
+		"src/main.go":    false,
+	}
+	for f, want := range cases {
+		if got := isDocPath(f); got != want {
+			t.Fatalf("isDocPath(%s)=%v want %v", f, got, want)
+		}
+	}
+}
+
+func TestCommentOnly(t *testing.T) {
+	dir := t.TempDir()
+	run := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+	run("git", "init")
+	run("git", "config", "user.email", "you@example.com")
+	run("git", "config", "user.name", "Your Name")
+	path := filepath.Join(dir, "main.go")
+	os.WriteFile(path, []byte("package main\n"), 0o644)
+	run("git", "add", "main.go")
+	run("git", "commit", "-m", "init")
+
+	// comment only change
+	os.WriteFile(path, []byte("package main\n// hi"), 0o644)
+	run("git", "add", "main.go")
+	cwd, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(cwd)
+	if !commentOnly("main.go") {
+		t.Fatalf("expected true")
+	}
+	// code change
+	os.WriteFile(path, []byte("package main\nvar x = 1"), 0o644)
+	run("git", "add", "main.go")
+	if commentOnly("main.go") {
+		t.Fatalf("expected false")
+	}
+}
+
+func TestIsCommentLine(t *testing.T) {
+	if !isCommentLine("main.go", "// foo") {
+		t.Fatalf("expected true")
+	}
+	if isCommentLine("main.go", "var x int") {
+		t.Fatalf("expected false")
+	}
+}
+
+func TestMainDocsOnly(t *testing.T) {
+	dir := t.TempDir()
+	run := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+	run("git", "init")
+	run("git", "config", "user.email", "you@example.com")
+	run("git", "config", "user.name", "Your Name")
+	path := filepath.Join(dir, "README.md")
+	os.WriteFile(path, []byte("hi"), 0o644)
+	run("git", "add", "README.md")
+	run("git", "commit", "-m", "init")
+
+	os.WriteFile(path, []byte("hi there"), 0o644)
+	run("git", "add", "README.md")
+	cwd, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(cwd)
+	if docsOnly := mainReturn(); !docsOnly {
+		t.Fatalf("expected docs-only")
+	}
+
+	// code change should flip result
+	code := filepath.Join(dir, "file.go")
+	os.WriteFile(code, []byte("package main"), 0o644)
+	run("git", "add", "file.go")
+	run("git", "commit", "-m", "code")
+	os.WriteFile(code, []byte("package main\nvar x int"), 0o644)
+	run("git", "add", "file.go")
+	if mainReturn() {
+		t.Fatalf("expected code-change")
+	}
+}
+
+func TestChangedFiles(t *testing.T) {
+	dir := t.TempDir()
+	run := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+	run("git", "init")
+	run("git", "config", "user.email", "you@example.com")
+	run("git", "config", "user.name", "Your Name")
+	os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hi"), 0o644)
+	run("git", "add", "a.txt")
+	run("git", "commit", "-m", "init")
+	os.WriteFile(filepath.Join(dir, "a.txt"), []byte("bye"), 0o644)
+	run("git", "add", "a.txt")
+	cwd, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(cwd)
+	files, err := changedFiles()
+	if err != nil || len(files) != 1 || files[0] != "a.txt" {
+		t.Fatalf("changedFiles unexpected: %v %v", files, err)
+	}
+}
+
+func mainReturn() bool {
+	files, err := changedFiles()
+	if err != nil || len(files) == 0 {
+		return false
+	}
+	for _, f := range files {
+		if !isDocPath(f) && !commentOnly(f) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary
- add ci-sieve helper tool and git hooks to detect docs-only commits
- skip CI pipeline on documentation updates via pipeline-guard job
- raise coverage gate to 93% and document the new policy
- fix ListModels logic in OpenAI client

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./... -coverprofile=coverage.out`
- `go tool cover -func=coverage.out | tail -n 1`

------
https://chatgpt.com/codex/tasks/task_e_684957760b6083269e6a5f17f73b6c87