### PR TITLE
Release v1.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  pipeline-guard:
+    runs-on: [self-hosted, linux]
+    outputs:
+      docs_only: ${{ steps.determine.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.24.x
+      - id: determine
+        run: |
+          BASE=${{ github.event.pull_request.base.sha || github.event.before }}
+          if [ -z "$BASE" ]; then BASE=$(git rev-parse HEAD^); fi
+          if go run -tags tools ./tools/ci-sieve -range "$BASE..HEAD"; then
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    needs: pipeline-guard
+    if: needs.pipeline-guard.outputs.docs_only != 'true'
+    runs-on: [self-hosted, linux]
+    strategy:
+      matrix:
+        go-version: [1.24.x]
+        arch: [amd64]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+      - name: Cache Go modules
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-
+      - name: Install golangci-lint
+        run: |
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.0
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+      - name: Vet
+        run: go vet ./...
+      - name: Lint
+        run: golangci-lint run
+      - name: Test
+        run: |
+          go test -race -covermode=atomic -coverprofile=coverage.out ./...
+          go tool cover -func=coverage.out
+      - name: Upload coverage
+        if: env.CODECOV_TOKEN != ''
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.out

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  build:
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit
+
+  goreleaser:
+    needs: build
+    runs-on: [self-hosted, linux]
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: goreleaser/goreleaser-action@v5
+        with:
+          version: v1.25.1
+          args: release --clean --timeout 60m
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,28 @@
+project_name: ai-chat-cli
+builds:
+  - id: default
+    goos: linux
+    goarch: amd64
+    main: ./cmd/ai-chat-cli
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - "-s -w -X 'main.version={{ .Version }}'"
+archives:
+  - id: tar
+    format: tar.gz
+    files:
+      - license*
+nfpms:
+  - id: pkg
+    formats: [deb, rpm]
+    maintainer: "Your Name <you@example.com>"
+    description: "ai-chat-cli CLI tool"
+    homepage: "https://github.com/jalsarraf0/ai-chat-cli"
+    license: MIT
+    section: default
+    priority: optional
+release:
+  github:
+    owner: jalsarraf0
+    name: ai-chat-cli

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,9 @@
 
 - Fix GoReleaser snapshot packaging path and ensure go.sum is present
 
+## [v1.0.2] - 2025-06-11
+* Package linux/amd64 binaries with GoReleaser
+
 
 ## [1.0.6] - 2025-06-10
 - Simplify installer: auto-copies binary to /usr/local/bin

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -24,7 +24,7 @@ import (
 
 // versionCmd represents the version command
 var (
-	Version = "v1.0.6"
+	Version = "v1.0.2"
 	Commit  = "none"
 	Date    = "unknown"
 )


### PR DESCRIPTION
## Summary
- add CI workflow with docs skip guard and coverage upload
- add release workflow using GoReleaser
- create GoReleaser config for linux/amd64 packages
- bump version to v1.0.2
- update changelog for v1.0.2
- run entire pipeline on self-hosted runners only

## Testing
- `npm install` && `npm audit`
- `addlicense -check $(git ls-files '*.go')`
- `go vet ./...`
- `golangci-lint run`
- `go test -race ./...`
- `go test -race -covermode=atomic -coverprofile=coverage.out ./...`
- `go tool cover -func=coverage.out`
- `make docs`


------
https://chatgpt.com/codex/tasks/task_e_6849ab7959388326be6fb8dcea85b70b