### PR TITLE
Fix text input not focused

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -55,6 +55,8 @@ func NewModel(initialRows int) Model {
 	ti := textinput.New()
 	ti.Prompt = "You: "
 	ti.Placeholder = "Ask me anything..."
+	ti.Focus()
+	ti.CharLimit = 512
 	m := Model{input: ti, height: initialRows, spinner: newSpinner()}
 	m.styles = LoadStyles("")
 	ti.PromptStyle = m.styles.Cursor


### PR DESCRIPTION
## Summary
- focus the text input widget so keys are processed
- limit input length to keep layout stable

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684e4f013bf88326b4c025ddb7e3bbe0